### PR TITLE
Avoid thumbnail-generation segfault in blender 2.79

### DIFF
--- a/netrender/thumbnail.py
+++ b/netrender/thumbnail.py
@@ -64,7 +64,7 @@ def _internal(filename):
             img = bpy.data.images[imagename]
             bpy.data.images.remove(img)
 
-        bpy.ops.image.open(filepath=filename)
+        bpy.data.images.load(filepath=filename)
         img = bpy.data.images[imagename]
             
         img.save_render(thumbname, scene=scene)


### PR DESCRIPTION
Updated script per note from Campbell Barton in bugreport https://developer.blender.org/T53294